### PR TITLE
Simple fixes for IronTracks

### DIFF
--- a/PTCGLDeckTracker/CardCollection/CardCollection.cs
+++ b/PTCGLDeckTracker/CardCollection/CardCollection.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using TPCI.Rainier.Match.Cards;
 
 namespace PTCGLDeckTracker.CardCollection
 {

--- a/PTCGLDeckTracker/CardCollection/Deck.cs
+++ b/PTCGLDeckTracker/CardCollection/Deck.cs
@@ -1,6 +1,7 @@
 ﻿using Harmony;
 using MelonLoader;
 using System.Collections.Generic;
+using TPCI.Rainier.Match.Cards;
 
 namespace PTCGLDeckTracker.CardCollection
 {

--- a/PTCGLDeckTracker/CardCollection/DiscardPile.cs
+++ b/PTCGLDeckTracker/CardCollection/DiscardPile.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using TPCI.Rainier.Match.Cards;
 
 namespace PTCGLDeckTracker.CardCollection
 {

--- a/PTCGLDeckTracker/CardCollection/Hand.cs
+++ b/PTCGLDeckTracker/CardCollection/Hand.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using TPCI.Rainier.Match.Cards;
 
 namespace PTCGLDeckTracker.CardCollection
 {

--- a/PTCGLDeckTracker/CardCollection/PrizeCards.cs
+++ b/PTCGLDeckTracker/CardCollection/PrizeCards.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using TPCI.Rainier.Match.Cards;
 
 namespace PTCGLDeckTracker.CardCollection
 {

--- a/PTCGLDeckTracker/IronTracks.cs
+++ b/PTCGLDeckTracker/IronTracks.cs
@@ -10,6 +10,7 @@ using MelonLoader;
 using RainierClientSDK;
 using UnityEngine.SceneManagement;
 using PTCGLDeckTracker.CardCollection;
+using TPCI.Rainier.Match.Cards.Ownership;
 
 namespace PTCGLDeckTracker
 {

--- a/PTCGLDeckTracker/Player.cs
+++ b/PTCGLDeckTracker/Player.cs
@@ -5,6 +5,8 @@ using System.Text;
 using System.Threading.Tasks;
 using MelonLoader;
 using PTCGLDeckTracker.CardCollection;
+using TPCI.Rainier.Match.Cards.Ownership;
+using TPCI.Rainier.Match.Cards;
 using static ContentItemCellRow;
 using static MelonLoader.MelonLogger;
 


### PR DESCRIPTION
During recent updates, PTCGL moved certain fields used in IronTracks, resulting in a 100% failure when loading the mod.

With the changes applied, I have tested on v1.24.0.440074.20250314_0204 on 2025/03/29 and verified that the mod worked as expected.

A local build is attached so that folks could save the time trying to build the project. Please rename it to PTCGLDeckTracker.dll and replace the old file in your /Mod under the game directory.

A lot of thanks to the original author for the remarkable work!

[PTCGLDeckTracker_rename_this_to_dll.txt](https://github.com/user-attachments/files/19523632/PTCGLDeckTracker_rename_this_to_dll.txt)
